### PR TITLE
feat: adicionando texto do README.md e .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Python
+*.pyc
+*.pyo
+*.pyd
+__pycache__/
+*.db
+*.log
+*.sqlite3
+
+# IDEs
+.vscode/
+.idea/
+*.swp
+
+# Environment variables
+.env
+
+# System Files 
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# usjt-protectplus
-Protect+ é uma solução desenvolvida por alunos da Universidade São Judas Tadeu no 1 semestre de 2025
+# 🔒 Protect+
+
+Este projeto foi desenvolvido por alunos da **Universidade São Judas Tadeu (USJT)** durante as Unidades Curriculares de **Sistemas Distribuídos e Mobile** e **Usabilidade, Desenvolvimento Web, Mobile e Jogos**, no **1º semestre de 2025**.
+
+## 👥 Integrantes do grupo
+
+| Nome | RA |
+|------|----|
+| Felipe Pinheiro Jofre | 824117237 |
+| Gustavo Lopes Silva | 82327145 |
+| Leonardo Henrique da Silva | 824214989 |
+| Marco Antonio Tavares Escudeiro | 824147959 |
+| Maria Eduarda Correia Lima Flor | 824147910 |
+| Nicole Ribeiro Pombal Bento | 82327297 |
+| Thaina Lima Matos | 822167399 |
+| Thamara Da Costa Lemos | 82327355 |


### PR DESCRIPTION
# Contexto
Este PR adiciona o conteúdo inicial do `README.md` com informações sobre o projeto Protect+, incluindo o nome dos integrantes e RA.
Também foi incluído o arquivo `.gitignore`, com regras para ignorar arquivos desnecessários como:

- Cache do Python
- Pastas de IDEs
- Arquivos de ambiente (.env)
- Lixos de sistema (ex: .DS_Store)

# O que foi feito
Adicionado texto ao README.md
Criado .gitignore para manter o repositório limpo e organizado